### PR TITLE
when critical, the pool name is slightly obscured

### DIFF
--- a/check_zpool_scrub
+++ b/check_zpool_scrub
@@ -518,7 +518,7 @@ if [ $LAST_SCRUB = -1 ]; then
 	RETURN=$STATE_UNKNOWN
 	echo "UNKNOWN: Failed to run zpool history"
 else
-	echo "$MESSAGE The last scrub on zpool “${OPT_POOL}” was performed on $(_timestamp_to_datetime $LAST_SCRUB) $(_performance_data)"
+	echo "$MESSAGE The last scrub on zpool '${OPT_POOL}' was performed on $(_timestamp_to_datetime $LAST_SCRUB) $(_performance_data)"
 fi
 
 exit $RETURN


### PR DESCRIPTION
At first, I thought this was an error in my configuration.

CRITICAL: The last scrub on zpool â€œzrootâ€ was performed on 2017-11-14.20:17:25 

Checking the code, I found magic quotes, which are neither double quotes (") nor single quotes (').