### PR TITLE
Performance data with units incl. time to go in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ POOL is the name of the pool
  - POOL_speed
     MB per second.
  - POOL_time
-    Time to go in minutes.
+    Time to go in seconds.
 
 Details about the implementation of this monitoring plugin:
 

--- a/check_zpool_scrub
+++ b/check_zpool_scrub
@@ -174,7 +174,7 @@ POOL is the name of the pool
  - POOL_speed
     MB per second.
  - POOL_time
-    Time to go in minutes.
+    Time to go in seconds.
 
 Details about the implementation of this monitoring plugin:
 
@@ -415,33 +415,32 @@ _grab_speed() {
 #   $1: The name of the pool.
 #
 # Return:
-#   The time to go in minutes as an integer number.
+#   The time to go in seconds as an integer number.
 ##
 _grab_time_to_go() {
-	local MINUTES HOURS DAYS
+	local SECONDS MINUTES HOURS DAYS
+	SECONDS=0
 	MINUTES=0
 	HOURS=0
 	DAYS=0
 	_get_line() {
 		_get_zpool_status_stdout "$1" | grep ' to go'
 	}
-	if [ -n "$(_get_zpool_status_stdout "$1" | grep '..:..:.. to go')" ]; then
+	if [ -n "$(_get_line "$1" | grep '..:..:.. to go')" ]; then
 		if [ -n "$(_get_line "$1" | grep days)" ]; then
-			DAYS="$(_get_line "$1" | sed -E 's/^.* (.*) days .*$/\1/g')"
+			DAYS="$(_get_line "$1" | sed -E 's/^.* (.*) days .*$/\1/')"
 		fi
-		HOURS="$(_get_line "$1" | sed -E 's/^.* (..):.*$/\1/g')"
-		MINUTES="$(_get_line "$1" | sed -E 's/^.*..:(..):.*$/\1/g')"
-		echo $((DAYS * 1440 + HOURS * 60 + MINUTES))
-	elif [ -n "$(_get_zpool_status_stdout "$1" | grep 'h.*m.*to go')" ]; then
+		HOURS="$(_get_line "$1" | sed -E 's/^.* (..):.*$/\1/')"
+		MINUTES="$(_get_line "$1" | sed -E 's/^.* ..:(..):.*$/\1/')"
+		SECONDS="$(_get_line "$1" | sed -E 's/^.* ..:..:(..).*$/\1/')"
+	elif [ -n "$(_get_line "$1" | grep 'h.*m.*to go')" ]; then
 		_get_duration() {
-			_get_line "$1" | sed -E 's/^.*, (.*h.*m) to go.*$/\1/g'
+			_get_line "$1" | sed -E 's/^.*, (.*h.*m) to go.*$/\1/'
 		}
 		HOURS=$(_get_duration "$1" | sed 's/h.*//')
-		MINUTES=$(_get_duration "$1" | sed -E 's/^.*, (.*h.*m) to go.*$/\1/g' | sed 's/.*h//' | sed 's/m//')
-		echo $((HOURS * 60 + MINUTES))
-	else
-		echo 0
+		MINUTES=$(_get_duration "$1" | sed -E 's/^.*, (.*h.*m) to go.*$/\1/' | sed 's/.*h//' | sed 's/m//')
 	fi
+	echo $(((DAYS * 1440 + HOURS * 60 + MINUTES) * 60 + SECONDS))
 }
 
 ##

--- a/check_zpool_scrub
+++ b/check_zpool_scrub
@@ -336,10 +336,10 @@ _grab_last_scrub_timestamp() {
 _performance_data_one_pool() {
 	local POOL="$1_"
 	echo "\
-${POOL}last_ago=$2;$OPT_WARNING;$OPT_CRITICAL \
-${POOL}progress=$3 \
+${POOL}last_ago=$2s;$OPT_WARNING;$OPT_CRITICAL;0 \
+${POOL}progress=$3%;;;0;100 \
 ${POOL}speed=$4 \
-${POOL}time=$5"
+${POOL}time=$5s"
 }
 
 ##

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -121,10 +121,10 @@ last ZFS scrub was performed." ]
 	local TEST="CRITICAL: The last scrub on zpool \
 'first_critical_zpool' was performed on 2017-06-16.10:25:47. \
 | \
-first_critical_zpool_last_ago=5356801;2678400;5356800 \
-first_critical_zpool_progress=100 \
+first_critical_zpool_last_ago=5356801s;2678400;5356800;0 \
+first_critical_zpool_progress=100%;;;0;100 \
 first_critical_zpool_speed=0 \
-first_critical_zpool_time=0"
+first_critical_zpool_time=0s"
 	[ "${lines[0]}" = "$TEST" ]
 }
 
@@ -134,10 +134,10 @@ first_critical_zpool_time=0"
 	local TEST="WARNING: The last scrub on zpool \
 'first_warning_zpool' was performed on 2017-07-17.10:25:47. \
 | \
-first_warning_zpool_last_ago=2678401;2678400;5356800 \
-first_warning_zpool_progress=72.38 \
+first_warning_zpool_last_ago=2678401s;2678400;5356800;0 \
+first_warning_zpool_progress=72.38%;;;0;100 \
 first_warning_zpool_speed=57.4 \
-first_warning_zpool_time=51120"
+first_warning_zpool_time=51120s"
 	[ "${lines[0]}" = "$TEST" ]
 }
 
@@ -147,10 +147,10 @@ first_warning_zpool_time=51120"
 	local TEST="OK: The last scrub on zpool 'first_ok_zpool' \
 was performed on 2017-08-17.10:25:48. \
 | \
-first_ok_zpool_last_ago=0;2678400;5356800 \
-first_ok_zpool_progress=96.19 \
+first_ok_zpool_last_ago=0s;2678400;5356800;0 \
+first_ok_zpool_progress=96.19%;;;0;100 \
 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=199980"
+first_ok_zpool_time=199980s"
 	[ "${lines[0]}" = "$TEST" ]
 }
 
@@ -172,10 +172,10 @@ WARNING: The last scrub on zpool 'first_warning_zpool' was performed on 2017-07-
 WARNING: The last scrub on zpool 'last_warning_zpool' was performed on 2017-06-16.10:25:48. \
 CRITICAL: The last scrub on zpool 'first_critical_zpool' was performed on 2017-06-16.10:25:47. \
 | \
-first_ok_zpool_last_ago=0;2678400;5356800 first_ok_zpool_progress=96.19 first_ok_zpool_speed=1.90 first_ok_zpool_time=199980 \
-last_ok_zpool_last_ago=2678400;2678400;5356800 last_ok_zpool_progress=96.19 last_ok_zpool_speed=1.90 last_ok_zpool_time=199980 \
-first_warning_zpool_last_ago=2678401;2678400;5356800 first_warning_zpool_progress=72.38 first_warning_zpool_speed=57.4 first_warning_zpool_time=51120 \
-last_warning_zpool_last_ago=5356800;2678400;5356800 last_warning_zpool_progress=72.38 last_warning_zpool_speed=57.4 last_warning_zpool_time=51120 \
-first_critical_zpool_last_ago=5356801;2678400;5356800 first_critical_zpool_progress=100 first_critical_zpool_speed=0 first_critical_zpool_time=0"
+first_ok_zpool_last_ago=0s;2678400;5356800;0 first_ok_zpool_progress=96.19%;;;0;100 first_ok_zpool_speed=1.90 first_ok_zpool_time=199980s \
+last_ok_zpool_last_ago=2678400s;2678400;5356800;0 last_ok_zpool_progress=96.19%;;;0;100 last_ok_zpool_speed=1.90 last_ok_zpool_time=199980s \
+first_warning_zpool_last_ago=2678401s;2678400;5356800;0 first_warning_zpool_progress=72.38%;;;0;100 first_warning_zpool_speed=57.4 first_warning_zpool_time=51120s \
+last_warning_zpool_last_ago=5356800s;2678400;5356800;0 last_warning_zpool_progress=72.38%;;;0;100 last_warning_zpool_speed=57.4 last_warning_zpool_time=51120s \
+first_critical_zpool_last_ago=5356801s;2678400;5356800;0 first_critical_zpool_progress=100%;;;0;100 first_critical_zpool_speed=0 first_critical_zpool_time=0s"
 	[ "${lines[0]}" = "$TEST" ]
 }

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -137,7 +137,7 @@ first_critical_zpool_time=0"
 first_warning_zpool_last_ago=2678401;2678400;5356800 \
 first_warning_zpool_progress=72.38 \
 first_warning_zpool_speed=57.4 \
-first_warning_zpool_time=852"
+first_warning_zpool_time=51120"
 	[ "${lines[0]}" = "$TEST" ]
 }
 
@@ -150,7 +150,7 @@ was performed on 2017-08-17.10:25:48. \
 first_ok_zpool_last_ago=0;2678400;5356800 \
 first_ok_zpool_progress=96.19 \
 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=3333"
+first_ok_zpool_time=199980"
 	[ "${lines[0]}" = "$TEST" ]
 }
 
@@ -172,10 +172,10 @@ WARNING: The last scrub on zpool 'first_warning_zpool' was performed on 2017-07-
 WARNING: The last scrub on zpool 'last_warning_zpool' was performed on 2017-06-16.10:25:48. \
 CRITICAL: The last scrub on zpool 'first_critical_zpool' was performed on 2017-06-16.10:25:47. \
 | \
-first_ok_zpool_last_ago=0;2678400;5356800 first_ok_zpool_progress=96.19 first_ok_zpool_speed=1.90 first_ok_zpool_time=3333 \
-last_ok_zpool_last_ago=2678400;2678400;5356800 last_ok_zpool_progress=96.19 last_ok_zpool_speed=1.90 last_ok_zpool_time=3333 \
-first_warning_zpool_last_ago=2678401;2678400;5356800 first_warning_zpool_progress=72.38 first_warning_zpool_speed=57.4 first_warning_zpool_time=852 \
-last_warning_zpool_last_ago=5356800;2678400;5356800 last_warning_zpool_progress=72.38 last_warning_zpool_speed=57.4 last_warning_zpool_time=852 \
+first_ok_zpool_last_ago=0;2678400;5356800 first_ok_zpool_progress=96.19 first_ok_zpool_speed=1.90 first_ok_zpool_time=199980 \
+last_ok_zpool_last_ago=2678400;2678400;5356800 last_ok_zpool_progress=96.19 last_ok_zpool_speed=1.90 last_ok_zpool_time=199980 \
+first_warning_zpool_last_ago=2678401;2678400;5356800 first_warning_zpool_progress=72.38 first_warning_zpool_speed=57.4 first_warning_zpool_time=51120 \
+last_warning_zpool_last_ago=5356800;2678400;5356800 last_warning_zpool_progress=72.38 last_warning_zpool_speed=57.4 last_warning_zpool_time=51120 \
 first_critical_zpool_last_ago=5356801;2678400;5356800 first_critical_zpool_progress=100 first_critical_zpool_speed=0 first_critical_zpool_time=0"
 	[ "${lines[0]}" = "$TEST" ]
 }

--- a/test/unit-without-mock.bats
+++ b/test/unit-without-mock.bats
@@ -37,6 +37,6 @@ setup() {
 @test "function _performance_data_one_pool" {
 	result="$(_performance_data_one_pool pool 1 2 3 4)"
   echo "$result" > $HOME/debug
-	[ "$result" = "pool_last_ago=1;2678400;5356800 pool_progress=2 pool_speed=3 \
-pool_time=4" ]
+	[ "$result" = "pool_last_ago=1s;2678400;5356800;0 pool_progress=2%;;;0;100 pool_speed=3 \
+pool_time=4s" ]
 }

--- a/test/unit.bats
+++ b/test/unit.bats
@@ -43,11 +43,11 @@ setup() {
 ##
 
 @test "function _grab_time_to_go" {
-	[ "$(_grab_time_to_go first_ok_zpool)" -eq 3333 ]
-	[ "$(_grab_time_to_go first_warning_zpool)" -eq 852 ]
+	[ "$(_grab_time_to_go first_ok_zpool)" -eq 199980 ]
+	[ "$(_grab_time_to_go first_warning_zpool)" -eq 51120 ]
 	[ "$(_grab_time_to_go first_critical_zpool)" -eq 0 ]
-	[ "$(_grab_time_to_go days_to_go)" -eq 61 ]
-	[ "$(_grab_time_to_go time_to_go_colons)" -eq 61 ]
+	[ "$(_grab_time_to_go days_to_go)" -eq 3681 ]
+	[ "$(_grab_time_to_go time_to_go_colons)" -eq 3681 ]
 }
 
 ##
@@ -61,7 +61,7 @@ setup() {
 was performed on 2017-08-17.10:25:48." ]
 	[ "$PERFORMANCE_DATA" = "first_ok_zpool_last_ago=0;2678400;5356800 \
 first_ok_zpool_progress=96.19 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=3333" ]
+first_ok_zpool_time=199980" ]
 }
 
 @test "function _check_one_pool days_to_go" {
@@ -71,7 +71,7 @@ first_ok_zpool_time=3333" ]
 was performed on 2017-08-17.10:25:48." ]
 	[ "$PERFORMANCE_DATA" = "days_to_go_last_ago=0;2678400;5356800 \
 days_to_go_progress=52.05 days_to_go_speed=120 \
-days_to_go_time=61" ]
+days_to_go_time=3681" ]
 }
 
 @test "function _check_multiple_pools first_ok_zpool" {
@@ -81,7 +81,7 @@ days_to_go_time=61" ]
 was performed on 2017-08-17.10:25:48." ]
 	[ "$PERFORMANCE_DATA" = "first_ok_zpool_last_ago=0;2678400;5356800 \
 first_ok_zpool_progress=96.19 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=3333" ]
+first_ok_zpool_time=199980" ]
 }
 
 
@@ -98,11 +98,11 @@ OK: The last scrub on zpool 'last_ok_zpool' was performed on \
 	TEST="first_ok_zpool_last_ago=0;2678400;5356800 \
 first_ok_zpool_progress=96.19 \
 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=3333 \
+first_ok_zpool_time=199980 \
 last_ok_zpool_last_ago=2678400;2678400;5356800 \
 last_ok_zpool_progress=96.19 \
 last_ok_zpool_speed=1.90 \
-last_ok_zpool_time=3333"
+last_ok_zpool_time=199980"
 	[ "$PERFORMANCE_DATA" = "$TEST" ]
 }
 

--- a/test/unit.bats
+++ b/test/unit.bats
@@ -59,9 +59,9 @@ setup() {
 	[ "$STATE" -eq 0 ]
 	[ "$MESSAGE" = "OK: The last scrub on zpool 'first_ok_zpool' \
 was performed on 2017-08-17.10:25:48." ]
-	[ "$PERFORMANCE_DATA" = "first_ok_zpool_last_ago=0;2678400;5356800 \
-first_ok_zpool_progress=96.19 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=199980" ]
+	[ "$PERFORMANCE_DATA" = "first_ok_zpool_last_ago=0s;2678400;5356800;0 \
+first_ok_zpool_progress=96.19%;;;0;100 first_ok_zpool_speed=1.90 \
+first_ok_zpool_time=199980s" ]
 }
 
 @test "function _check_one_pool days_to_go" {
@@ -69,9 +69,9 @@ first_ok_zpool_time=199980" ]
 	[ "$STATE" -eq 0 ]
 	[ "$MESSAGE" = "OK: The last scrub on zpool 'days_to_go' \
 was performed on 2017-08-17.10:25:48." ]
-	[ "$PERFORMANCE_DATA" = "days_to_go_last_ago=0;2678400;5356800 \
-days_to_go_progress=52.05 days_to_go_speed=120 \
-days_to_go_time=3681" ]
+	[ "$PERFORMANCE_DATA" = "days_to_go_last_ago=0s;2678400;5356800;0 \
+days_to_go_progress=52.05%;;;0;100 days_to_go_speed=120 \
+days_to_go_time=3681s" ]
 }
 
 @test "function _check_multiple_pools first_ok_zpool" {
@@ -79,9 +79,9 @@ days_to_go_time=3681" ]
 	[ "$STATE" -eq 0 ]
 	[ "$MESSAGE" = "OK: The last scrub on zpool 'first_ok_zpool' \
 was performed on 2017-08-17.10:25:48." ]
-	[ "$PERFORMANCE_DATA" = "first_ok_zpool_last_ago=0;2678400;5356800 \
-first_ok_zpool_progress=96.19 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=199980" ]
+	[ "$PERFORMANCE_DATA" = "first_ok_zpool_last_ago=0s;2678400;5356800;0 \
+first_ok_zpool_progress=96.19%;;;0;100 first_ok_zpool_speed=1.90 \
+first_ok_zpool_time=199980s" ]
 }
 
 
@@ -95,14 +95,14 @@ OK: The last scrub on zpool 'last_ok_zpool' was performed on \
 2017-07-17.10:25:48."
 	[ "$MESSAGE" = "$TEST" ]
 
-	TEST="first_ok_zpool_last_ago=0;2678400;5356800 \
-first_ok_zpool_progress=96.19 \
+	TEST="first_ok_zpool_last_ago=0s;2678400;5356800;0 \
+first_ok_zpool_progress=96.19%;;;0;100 \
 first_ok_zpool_speed=1.90 \
-first_ok_zpool_time=199980 \
-last_ok_zpool_last_ago=2678400;2678400;5356800 \
-last_ok_zpool_progress=96.19 \
+first_ok_zpool_time=199980s \
+last_ok_zpool_last_ago=2678400s;2678400;5356800;0 \
+last_ok_zpool_progress=96.19%;;;0;100 \
 last_ok_zpool_speed=1.90 \
-last_ok_zpool_time=199980"
+last_ok_zpool_time=199980s"
 	[ "$PERFORMANCE_DATA" = "$TEST" ]
 }
 


### PR DESCRIPTION
Suggestions regarding #13, incl. a breaking change regarding the time to go unit:

* unit and min for `*_last_ago`
* unit, min and max for `*_progress`
* unit for `*_time`

The last one requires changing the time to go from minutes to seconds, that's o.c. a breaking change you might want to refuse.

Also some other minor changes/fixes in the `_grab_time_to_go` function.